### PR TITLE
catch up with gym 0.26.1

### DIFF
--- a/gym_gridworlds/envs/cliff_env.py
+++ b/gym_gridworlds/envs/cliff_env.py
@@ -3,20 +3,19 @@ from gym import spaces
 
 
 class CliffEnv(gym.Env):
+
     def __init__(self):
         self.height = 4
         self.width = 12
         self.action_space = spaces.Discrete(4)
-        self.observation_space = spaces.Tuple((
-                spaces.Discrete(self.height),
-                spaces.Discrete(self.width)
-                ))
+        self.observation_space = spaces.Tuple(
+            (spaces.Discrete(self.height), spaces.Discrete(self.width)))
         self.moves = {
-                0: (-1, 0),   # up
-                1: (0, 1),   # right
-                2: (1, 0),  # down
-                3: (0, -1),  # left
-                }
+            0: (-1, 0),  # up
+            1: (0, 1),  # right
+            2: (1, 0),  # down
+            3: (0, -1),  # left
+        }
 
         # begin in start state
         self.reset()
@@ -26,8 +25,8 @@ class CliffEnv(gym.Env):
         self.S = self.S[0] + x, self.S[1] + y
 
         self.S = max(0, self.S[0]), max(0, self.S[1])
-        self.S = (min(self.S[0], self.height - 1),
-                  min(self.S[1], self.width - 1))
+        self.S = (min(self.S[0],
+                      self.height - 1), min(self.S[1], self.width - 1))
 
         if self.S == (self.height - 1, self.width - 1):
             return self.S, -1, True, {}
@@ -36,6 +35,6 @@ class CliffEnv(gym.Env):
             return self.reset(), -100, False, {}
         return self.S, -1, False, {}
 
-    def reset(self):
+    def reset(self, seed=None, options=None):
         self.S = (3, 0)
-        return self.S
+        return self.S, {}

--- a/gym_gridworlds/envs/windy_gridworld_env.py
+++ b/gym_gridworlds/envs/windy_gridworld_env.py
@@ -3,20 +3,19 @@ from gym import spaces
 
 
 class WindyGridworldEnv(gym.Env):
+
     def __init__(self):
         self.height = 7
         self.width = 10
         self.action_space = spaces.Discrete(4)
-        self.observation_space = spaces.Tuple((
-                spaces.Discrete(self.height),
-                spaces.Discrete(self.width)
-                ))
+        self.observation_space = spaces.Tuple(
+            (spaces.Discrete(self.height), spaces.Discrete(self.width)))
         self.moves = {
-                0: (-1, 0),  # up
-                1: (0, 1),   # right
-                2: (1, 0),   # down
-                3: (0, -1),  # left
-                }
+            0: (-1, 0),  # up
+            1: (0, 1),  # right
+            2: (1, 0),  # down
+            3: (0, -1),  # left
+        }
 
         # begin in start state
         self.reset()
@@ -31,13 +30,15 @@ class WindyGridworldEnv(gym.Env):
         self.S = self.S[0] + x, self.S[1] + y
 
         self.S = max(0, self.S[0]), max(0, self.S[1])
-        self.S = (min(self.S[0], self.height - 1),
-                  min(self.S[1], self.width - 1))
+        self.S = (
+            min(self.S[0], self.height - 1),
+            min(self.S[1], self.width - 1),
+        )
 
         if self.S == (3, 7):
             return self.S, -1, True, {}
         return self.S, -1, False, {}
 
-    def reset(self):
+    def reset(self, seed=None, options=None):
         self.S = (3, 0)
-        return self.S
+        return self.S, {}

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
 from setuptools import setup, find_packages
 
-
 with open('README.rst') as f:
     long_description = ''.join(f.readlines())
 
 setup(
-        name='gym_gridworlds',
-        version='0.0.2',
-        description='Gridworlds environments for OpenAI gym.',
-        long_description=long_description,
-        author='Ondřej Podsztavek',
-        author_email='ondrej.podsztavek@gmail.com',
-        license='MIT License',
-        url='https://github.com/podondra/gym-gridworlds',
-        packages=find_packages(),
-        install_requires=['gym', 'numpy'],
-        setup_requires=['pytest-runner'],
-        tests_require=['pytest'],
-        )
+    name='gym_gridworlds',
+    version='0.0.3',
+    description='Gridworlds environments for OpenAI gym.',
+    long_description=long_description,
+    author='Ondřej Podsztavek',
+    author_email='ondrej.podsztavek@gmail.com',
+    license='MIT License',
+    url='https://github.com/podondra/gym-gridworlds',
+    packages=find_packages(),
+    install_requires=['gym', 'numpy'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
+)


### PR DESCRIPTION
Current master version code is not compatible with gym v0.26 api, which requires:
```
# reset function should return additional info objects (a dict)
# and also takes two more args, i.e. seed and options
def reset(self, seed=None, options=None)
    ...
    return observations, info
```
Detail can be found at openai-gym doc: [link](https://www.gymlibrary.dev/content/environment_creation/#reset)

